### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -43,7 +43,7 @@ const provider = (baseProvider, options, app) => {
 	const terminator = getTerminator(options);
 
 	return {
-		createSchema({ schemaName, databaseName, ifNotExist, isActivated }) {
+		createSchema({ schemaName, databaseName, ifNotExist, isActivated = true }) {
 			const schemaTerminator = ifNotExist ? ';' : terminator;
 			let schemaStatement = commentIfDeactivated(
 				assignTemplates(templates.createSchema, {

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -43,12 +43,15 @@ const provider = (baseProvider, options, app) => {
 	const terminator = getTerminator(options);
 
 	return {
-		createSchema({ schemaName, databaseName, ifNotExist }) {
+		createSchema({ schemaName, databaseName, ifNotExist, isActivated }) {
 			const schemaTerminator = ifNotExist ? ';' : terminator;
-			let schemaStatement = assignTemplates(templates.createSchema, {
-				name: schemaName,
-				terminator: schemaTerminator,
-			});
+			let schemaStatement = commentIfDeactivated(
+				assignTemplates(templates.createSchema, {
+					name: schemaName,
+					terminator: schemaTerminator,
+				}),
+				{ isActivated },
+			);
 
 			if (!databaseName) {
 				return ifNotExist
@@ -375,6 +378,7 @@ const provider = (baseProvider, options, app) => {
 				schemaName: containerData.name,
 				databaseName: containerData.databaseName,
 				ifNotExist: containerData.ifNotExist,
+				isActivated: containerData.isActivated,
 			};
 		},
 

--- a/forward_engineering/helpers/commentIfDeactivated.js
+++ b/forward_engineering/helpers/commentIfDeactivated.js
@@ -2,7 +2,7 @@ const BEFORE_DEACTIVATED_STATEMENT = '-- ';
 const REG_FOR_MULTYLINE_COMMENT = /(\n\/\*\n[\s\S]*?\n\s\*\/\n)|((\n\/\*\n[\s\S]*?\n\s\*\/)$)/gi;
 
 const commentIfDeactivated = (statement, data, isPartOfLine) => {
-	if (data?.hasOwnProperty('isActivated') && !data.isActivated) {
+	if (data.isActivated === false) {
 		if (isPartOfLine) {
 			return '/* ' + statement + ' */';
 		} else if (statement.includes('\n')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Synapse",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Synapse",
-			"version": "0.2.12",
+			"version": "0.2.13",
 			"dependencies": {
 				"@azure/msal-node": "2.9.2",
 				"axios": "1.7.2",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...