### PR TITLE
HCK-9945: updated config with synonyms for proper RE from PowerDesigner

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1471,7 +1471,7 @@ making sure that you maintain a proper JSON format.
 				"defaultValue": "",
 				"dependency": {
 					"key": "mode",
-					"value": "binary"
+					"value": "varbinary"
 				}
 			},
 			{

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -879,6 +879,40 @@ making sure that you maintain a proper JSON format.
 				"valueType": "string"
 			},
 			{
+				"propertyName": "Synonym",
+				"propertyKeyword": "synonym",
+				"propertyTooltip": "Select from list of options",
+				"propertyType": "select",
+				"options": ["", "dec"],
+				"defaultValue": "",
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "mode",
+							"value": "decimal"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "Synonym",
+				"propertyKeyword": "synonym",
+				"propertyTooltip": "Select from list of options",
+				"propertyType": "select",
+				"options": ["", "double precision"],
+				"defaultValue": "",
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "mode",
+							"value": "float"
+						}
+					]
+				}
+			},
+			{
 				"propertyName": "Precision",
 				"propertyKeyword": "precision",
 				"propertyType": "numeric",
@@ -1437,6 +1471,23 @@ making sure that you maintain a proper JSON format.
 				"options": ["binary", "varbinary"],
 				"data": "options",
 				"valueType": "string"
+			},
+			{
+				"propertyName": "Synonym",
+				"propertyKeyword": "synonym",
+				"propertyTooltip": "Select from list of options",
+				"propertyType": "select",
+				"options": ["", "binary varying"],
+				"defaultValue": "",
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "mode",
+							"value": "binary"
+						}
+					]
+				}
 			},
 			{
 				"propertyName": "Has max length",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -886,13 +886,8 @@ making sure that you maintain a proper JSON format.
 				"options": ["", "dec"],
 				"defaultValue": "",
 				"dependency": {
-					"type": "and",
-					"values": [
-						{
-							"key": "mode",
-							"value": "decimal"
-						}
-					]
+					"key": "mode",
+					"value": "decimal"
 				}
 			},
 			{
@@ -903,13 +898,8 @@ making sure that you maintain a proper JSON format.
 				"options": ["", "double precision"],
 				"defaultValue": "",
 				"dependency": {
-					"type": "and",
-					"values": [
-						{
-							"key": "mode",
-							"value": "float"
-						}
-					]
+					"key": "mode",
+					"value": "float"
 				}
 			},
 			{
@@ -1480,13 +1470,8 @@ making sure that you maintain a proper JSON format.
 				"options": ["", "binary varying"],
 				"defaultValue": "",
 				"dependency": {
-					"type": "and",
-					"values": [
-						{
-							"key": "mode",
-							"value": "binary"
-						}
-					]
+					"key": "mode",
+					"value": "binary"
 				}
 			},
 			{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9945" title="HCK-9945" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9945</a>  Synapse: add missing type synonyms to improve data type mapping from PowerDesigner PDM files (similar to MSSQL-server)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Add synonyms for proper types resolve on RE from PowerDesigner