### PR TITLE
HCK-12336: remove redundant ASC keyword in PK and UK constraints FE script

### DIFF
--- a/forward_engineering/helpers/constraintsHelper.js
+++ b/forward_engineering/helpers/constraintsHelper.js
@@ -9,7 +9,7 @@ module.exports = app => {
 
 	const createKeyConstraint = (templates, terminator, isParentActivated) => keyData => {
 		const partition = keyData.partition ? ` ON [${keyData.partition}]` : '';
-		const columnMapToString = ({ name, order }) => `[${name}] ${order}`.trim();
+		const columnMapToString = ({ name }) => `[${name}]`.trim();
 
 		const isAllColumnsDeactivated = checkAllKeysDeactivated(keyData.columns);
 

--- a/forward_engineering/helpers/keyHelper.js
+++ b/forward_engineering/helpers/keyHelper.js
@@ -65,16 +65,6 @@ module.exports = app => {
 		}
 	};
 
-	const getOrder = order => {
-		if (_.toLower(order) === 'asc') {
-			return 'ASC';
-		} else if (_.toLower(order) === 'desc') {
-			return 'DESC';
-		} else {
-			return '';
-		}
-	};
-
 	const hydrateUniqueOptions = (options, columnName, isActivated) =>
 		clean({
 			keyType: 'UNIQUE',
@@ -82,7 +72,6 @@ module.exports = app => {
 			columns: [
 				{
 					name: columnName,
-					order: getOrder(options['order']),
 					isActivated: isActivated,
 				},
 			],
@@ -108,7 +97,6 @@ module.exports = app => {
 			columns: [
 				{
 					name: columnName,
-					order: getOrder(options['order']),
 					isActivated: isActivated,
 				},
 			],
@@ -143,7 +131,6 @@ module.exports = app => {
 		return keys.map(key => {
 			return {
 				name: findName(key.keyId, jsonSchema.properties),
-				order: key.type === 'descending' ? 'DESC' : 'ASC',
 				isActivated: checkIfActivated(key.keyId, jsonSchema.properties),
 			};
 		});

--- a/reverse_engineering/reverseEngineeringService/helpers/defineFieldsCompositeKeyConstraints.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/defineFieldsCompositeKeyConstraints.js
@@ -7,7 +7,7 @@ const PRIMARY_KEY = 'PRIMARY KEY';
 const reverseCompositeKeys = keyConstraintsInfo => {
 	const keyCompositionStatuses = getKeyConstraintsCompositionStatuses(keyConstraintsInfo);
 	return keyConstraintsInfo.reduce((reversedKeys, keyConstraintInfo) => {
-		const { columnName, constraintName, constraintType, isDescending } = keyConstraintInfo;
+		const { columnName, constraintName, constraintType } = keyConstraintInfo;
 		const compositionStatus = keyCompositionStatuses[constraintName];
 		const existingReversedKey = reversedKeys[constraintName];
 		const keyType = constraintType === PRIMARY_KEY ? 'compositePrimaryKey' : 'compositeUniqueKey';
@@ -24,7 +24,6 @@ const reverseCompositeKeys = keyConstraintsInfo => {
 					[keyType]: [
 						{
 							name: columnName,
-							type: isDescending ? 'descending' : 'ascending',
 						},
 					],
 				},
@@ -44,7 +43,6 @@ const reverseCompositeKeys = keyConstraintsInfo => {
 					...existingReversedKey[keyType],
 					{
 						name: columnName,
-						type: isDescending ? 'descending' : 'ascending',
 					},
 				],
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12336" title="HCK-12336" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12336</a>  Remove ASC from PK and UK Synapse constraints
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Removed redundant ASC in PK and UK from FE script