### PR TITLE
HCK-13038: adjust Azure MFA auth for RE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
 	"name": "Synapse",
-	"version": "0.2.22",
+	"version": "0.2.23",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Synapse",
-			"version": "0.2.22",
+			"version": "0.2.23",
 			"dependencies": {
-				"@azure/msal-node": "3.8.0",
 				"@hackolade/fetch": "1.3.0",
 				"base64url": "3.0.1",
 				"crypto": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "icon_url": "logo.jpg",
     "disabled": false,
     "dependencies": {
-        "@azure/msal-node": "3.8.0",
         "@hackolade/fetch": "1.3.0",
         "base64url": "3.0.1",
         "crypto": "1.0.1",

--- a/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
+++ b/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
@@ -53,6 +53,7 @@
 			{
 				"inputLabel": "Host",
 				"inputKeyword": "host",
+				"inputPlaceholder": "Host",
 				"description": "Specify Azure Synapse server name",
 				"inputType": "text",
 				"dependency": {
@@ -117,7 +118,7 @@
 					},
 					{
 						"value": "Azure Active Directory (MFA)",
-						"label": "Azure Active Directory (MFA)"
+						"label": "Azure Entra ID (MFA)"
 					}
 				]
 			},
@@ -155,17 +156,7 @@
 				"inputTooltip": "Specify the Tenant ID from the Overview screen of your Azure AD tenant",
 				"dependency": {
 					"key": "authMethod",
-					"value": ["Azure Active Directory (Username / Password)", "Azure Active Directory (MFA)"]
-				}
-			},
-			{
-				"inputLabel": "User Name",
-				"inputKeyword": "loginHint",
-				"inputType": "text",
-				"inputPlaceholder": "User Name",
-				"dependency": {
-					"key": "authMethod",
-					"value": ["Azure Active Directory (MFA)"]
+					"value": ["Azure Active Directory (Username / Password)"]
 				}
 			}
 		]

--- a/reverse_engineering/databaseService/helpers/connection.js
+++ b/reverse_engineering/databaseService/helpers/connection.js
@@ -1,6 +1,5 @@
 const { hckFetch } = require('@hackolade/fetch');
 const sql = require('mssql');
-const msal = require('@azure/msal-node');
 const { logAuthTokenInfo, logConnectionHostAndUsername } = require('../../helpers/logInfo');
 const { prepareError } = require('./errorService');
 const { parseResponse } = require('../../helpers/parseResponse');

--- a/reverse_engineering/helpers/parseConnectionString.js
+++ b/reverse_engineering/helpers/parseConnectionString.js
@@ -33,7 +33,7 @@ const parseSqlServerUrl = ({ url = '' }) => {
 	return {
 		host,
 		port: port ? Number(port) : null,
-		databaseName: params.databaseName,
+		databaseName: params.databaseName || params.database,
 		userName: params.user,
 		userPassword: params.password,
 	};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13038" title="HCK-13038" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13038</a>  [Inotive][SQLServer] Enable/fix connection with MS Entra ID to leverage connection to Microsoft Fabric in that plugin (similar to Avro)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR adjusts the Azure MFA authentication flow for reverse-engineering.

**Changes:**
- Removed `@azure/msal-node` package as it is no longer used.
- Renamed the authentication option "Azure Active Directory" to "Azure Entra ID".
- Removed "Tenant ID" and "User name" parameters for "Azure Entra ID", as they are not used.
- Adjusted the logic for parsing the database name from the connection string.