### PR TITLE
HCK-13057: Change labels for Microsoft Entra authentication methods

### DIFF
--- a/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
+++ b/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
@@ -113,12 +113,12 @@
 						"label": "SQL Server"
 					},
 					{
-						"value": "Azure Active Directory (Username / Password)",
-						"label": "Azure Active Directory (Username / Password)"
+						"value": "Azure Active Directory (MFA)",
+						"label": "Microsoft Entra ID via authorization code flow (PCKE)"
 					},
 					{
-						"value": "Azure Active Directory (MFA)",
-						"label": "Azure Entra ID (MFA)"
+						"value": "Azure Active Directory (Username / Password)",
+						"label": "Microsoft Entra ID via username/password (ROPC - legacy)"
 					}
 				]
 			},


### PR DESCRIPTION
Microsoft rebranded its authentication method from Active Directory to Entra. The two options were renamed to align with the new name and to clarify their distinctions.

The recommended method (authentication flow) has been put first (as recommended over the username/password)