### PR TITLE
HCK-15015: comments are not ignored when start with ---

### DIFF
--- a/forward_engineering/helpers/commentIfDeactivated.js
+++ b/forward_engineering/helpers/commentIfDeactivated.js
@@ -1,4 +1,4 @@
-const BEFORE_DEACTIVATED_STATEMENT = '-- ';
+const BEFORE_DEACTIVATED_STATEMENT = '--';
 const REG_FOR_MULTILINE_COMMENT = /(\n\/\*\n[\s\S]*?\n\s\*\/\n)|((\n\/\*\n[\s\S]*?\n\s\*\/)$)/gi;
 
 const commentIfDeactivated = (statement, data, isPartOfLine) => {
@@ -8,7 +8,7 @@ const commentIfDeactivated = (statement, data, isPartOfLine) => {
 		} else if (statement.includes('\n')) {
 			return '/*\n' + statement + ' */\n';
 		} else {
-			return BEFORE_DEACTIVATED_STATEMENT + statement;
+			return BEFORE_DEACTIVATED_STATEMENT + ' ' + statement;
 		}
 	}
 	return statement;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-15015" title="HCK-15015" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-15015</a>  [Azure Synapse][Script hooks][Apply to DB] Apply to DB is failed in case if any script hook is present for the model
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Technical details

If a comment does not start with `-- ` that includes a space, it's not treated as a commented line.
